### PR TITLE
clang only flag added, optimized flags

### DIFF
--- a/bashrc.d/40-flag.sh
+++ b/bashrc.d/40-flag.sh
@@ -126,8 +126,7 @@ FLAG_FILTER_FORTRAN=(
 	'-fsigned-*'
 	'-fsso-struct*'
 	'-funsigned-*'
-	'-Wformat=1'
-	'-Wformat-security'
+	'-Wformat*'
 )
 
 FLAG_FILTER_FFLAGS=(
@@ -174,6 +173,7 @@ FLAG_FILTER_NONGNU=(
 FLAG_FILTER_GNU=(
 	'-emit-llvm'
 	'-flto=thin'
+	'-fopenmp=*'
 	'-fsanitize=cfi'
 	'-fsanitize=safe-stack'
 	'-mllvm'


### PR DESCRIPTION
all of Wformat flags are invalid for FORTRAN
GCC accepts -fopenmp (CLANG too) but with CLANG you can specify the library with -fopenmp=lib* (and GCC does not support this) so I filter this out