### PR TITLE
Add -fdevirtualize-at-ltrans to FLAG_FILTER_NONGNU

### DIFF
--- a/bashrc.d/40-flag.sh
+++ b/bashrc.d/40-flag.sh
@@ -141,6 +141,7 @@ FLAG_FILTER_F77FLAGS=(
 
 FLAG_FILTER_NONGNU=(
 	'-fcf-protection*'
+	'-fdevirtualize-at-ltrans'
 	'-fdevirtualize-speculatively'
 	'-fdirectives-only'
 	'-fgcse*'


### PR DESCRIPTION
I encountered an error building rust with the Gentoo LTO overlay enabled because it tried to pass `-fdevirtualize-at-ltrans` to clang during the build process, which caused an error since clang (8.0.0 on my system) does not support this flag. See https://github.com/InBetweenNames/gentooLTO/pull/345