### PR TITLE
Enable better filtering of LTO flags

### DIFF
--- a/bashrc.d/40-flag.sh
+++ b/bashrc.d/40-flag.sh
@@ -152,7 +152,9 @@ FLAG_FILTER_NONGNU=(
 	'-fisolate-erroneous-paths-attribute'
 	'-fivopts'
 	'-floop*'
-	'-flto-*'
+	'-flto=[0-9]*'
+	'-flto-partition=*'
+	'-flto-compression-level=*'
 	'-fmodulo*'
 	'-fno-enforce-eh-specs'
 	'-fno-ident'
@@ -180,7 +182,8 @@ FLAG_FILTER_NONGNU=(
 
 FLAG_FILTER_GNU=(
 	'-emit-llvm'
-	'-flto=thin'
+	'-flto=[a-z]*'
+	'-flto-jobs=*'
 	'-fopenmp=*'
 	'-frewrite-includes'
 	'-fsanitize=cfi'


### PR DESCRIPTION
Currently in _40-flag.sh_, a flag such as `-flto=4` gets passed to a build even when `USE_NONGNU=1` is set, and flags such as `-flto-jobs=4` get filtered out when they shouldn't. The following commit fixes such behavior.

See https://github.com/InBetweenNames/gentooLTO/issues/355.