### PR TITLE
enable -fstack-clash-protection on clang

### DIFF
--- a/bashrc.d/10-flag.sh
+++ b/bashrc.d/10-flag.sh
@@ -176,7 +176,6 @@ FLAG_FILTER_NONGNU=(
 	'-frerun-cse-after-loop'
 	'-fsched*'
 	'-fsection-anchors'
-	'-fstack-clash-protection'
 	'-ftree*'
 	'-funsafe-loop*'
 	'-fuse-linker-plugin'


### PR DESCRIPTION
clang supports -fstack-clash-protection since clang-11.0.0