### PR TITLE
filter LTO-requiring flags if LTO is not enabled on clang

### DIFF
--- a/bashrc.d/10-flag.sh
+++ b/bashrc.d/10-flag.sh
@@ -204,6 +204,11 @@ FLAG_FILTER_GNU=(
 	'-Wl,-z,retpolineplt'
 )
 
+FLAG_FILTER_CLANG_LTO_DEP=(
+	'-fsanitize=cfi*'
+	'-fwhole-program-vtables'
+)
+
 FlagEval() {
 	case $- in
 	*f*)	eval "$*";;
@@ -594,6 +599,12 @@ FlagSetNonGNU() {
 	FlagSubAllFlags "${FLAG_FILTER_NONGNU[@]}"
 	FlagReplaceAllFlags '-fstack-check*' '-fstack-check'
 	# FlagAddCFlags '-flto' '-emit-llvm'
+	case " $LDFLAGS $CFLAGS $CXXFLAGS" in
+	*[[:space:]]'-flto'*)
+		;;
+	*)
+		FlagSubAllFlags "${FLAG_FILTER_CLANG_LTO_DEP[@]}";;
+	esac
 }
 
 FlagSetGNU() {

--- a/bashrc.d/10-flag.sh
+++ b/bashrc.d/10-flag.sh
@@ -196,7 +196,7 @@ FLAG_FILTER_GNU=(
 	'-flto-jobs=*'
 	'-fopenmp=*'
 	'-frewrite-includes'
-	'-fsanitize=cfi'
+	'-fsanitize=cfi*'
 	'-fsanitize=safe-stack'
 	'-mllvm'
 	'-mretpoline*'


### PR DESCRIPTION
Clang has a few flags that require -flto to be set, and errors out otherwise (namely -fsanitize=cfi* and -fwhole-program-vtables), this filters them if -flto isn't set.

Additionally, fix FLAG_FILTER_GNU to also filter cfi sub-options like -fsanitize=cfi-vcall