### PR TITLE
Set USE_NONGNU=1 with USE flag +clang

### DIFF
--- a/bashrc.d/10-flag.sh
+++ b/bashrc.d/10-flag.sh
@@ -582,6 +582,7 @@ FlagScanDir() {
 }
 
 FlagSetUseNonGNU() {
+	has clang ${IUSE//+} && use clang && return 0
 	case $CC$CXX in
 	*clang*)
 		return 0;;


### PR DESCRIPTION
Before checking $CC$CXX, this will check if the clang USE flag exists in the package's IUSE, then if clang is enabled for the package. It fixes the issue of USE +clang forcing the clang compiler without USE_NONGNU being set. 