### PR TITLE
Set USE_NONGNU=1 simply with clang USE flag enabled

### DIFF
--- a/bashrc.d/10-flag.sh
+++ b/bashrc.d/10-flag.sh
@@ -713,7 +713,7 @@ FlagScanDir() {
 }
 
 FlagSetUseNonGNU() {
-	has clang ${IUSE//+} && use clang && return 0
+	use clang && return 0
 	case $CC$CXX in
 	*clang*)
 		return 0;;


### PR DESCRIPTION
Some packages do not have clang USE flag enabled by default, setting `USE_NONGNU` is still necessary when enabled.

However, clang USE flag of some packages does not indicate using clang for compilation. Is it possible to filter them?